### PR TITLE
reexport 'distance_to' which was available in 0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "osm4routing"
 edition = "2021"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 description = "Convert OpenStreetMap data into routing friendly CSV"
 homepage = "https://github.com/Tristramg/osm4routing2"

--- a/src/osm4routing/models.rs
+++ b/src/osm4routing/models.rs
@@ -7,7 +7,7 @@ pub use osmpbfreader::objects::{NodeId, WayId};
 // Coord are coordinates in decimal degress WGS84
 type Coord = geo_types::Coord<f64>;
 
-trait Distance {
+pub trait Distance {
     fn distance_to(&self, end: Coord) -> f64;
 }
 


### PR DESCRIPTION
In 0.6.4, `Coord` has been replaced by `geo_types::Coord`. But there was a `distance_to` function on which some users were depending on. This PR will expose it again.