### PR TITLE
Switch to osmpbfreader 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "osm4routing"
 edition = "2021"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 description = "Convert OpenStreetMap data into routing friendly CSV"
 homepage = "https://github.com/Tristramg/osm4routing2"
@@ -9,7 +9,7 @@ readme = "readme.md"
 license = "MIT"
 
 [dependencies]
-osmpbfreader = "0.16.1"
+osmpbfreader = "0.17.0"
 csv = "1.3.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = "1.0"


### PR DESCRIPTION
The goal is to use protobuf3 is osmpbfreader, that will avoid compiling twice protobuf for projects that have other uses for it