### PR TITLE
Replace standard library HashMap / HashSet with ahash 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "osm4routing"
 edition = "2021"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 description = "Convert OpenStreetMap data into routing friendly CSV"
 homepage = "https://github.com/Tristramg/osm4routing2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 osmpbfreader = "0.17.0"
+ahash = "0.8"
 csv = "1.3.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = "1.0"

--- a/src/osm4routing/models.rs
+++ b/src/osm4routing/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::HashMap;
 use std::hash::{Hash, Hasher};
 
 use super::categorize::EdgeProperties;
@@ -56,7 +56,7 @@ pub struct Edge {
     pub geometry: Vec<Coord>,
     pub properties: EdgeProperties,
     pub nodes: Vec<NodeId>,
-    pub tags: std::collections::HashMap<String, String>,
+    pub tags: HashMap<String, String>,
 }
 
 impl Hash for Edge {

--- a/src/osm4routing/reader.rs
+++ b/src/osm4routing/reader.rs
@@ -1,7 +1,7 @@
 use super::categorize::*;
 use super::models::*;
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use osmpbfreader::objects::{NodeId, WayId};
-use ahash::{HashMap, HashSet, HashMapExt, HashSetExt};
 use std::path::Path;
 
 // Way as represented in OpenStreetMap

--- a/src/osm4routing/reader.rs
+++ b/src/osm4routing/reader.rs
@@ -1,7 +1,7 @@
 use super::categorize::*;
 use super::models::*;
 use osmpbfreader::objects::{NodeId, WayId};
-use std::collections::{HashMap, HashSet};
+use ahash::{HashMap, HashSet, HashMapExt, HashSetExt};
 use std::path::Path;
 
 // Way as represented in OpenStreetMap
@@ -160,7 +160,7 @@ impl Reader {
             }
         }
 
-        for edge in edges.into_iter() {
+        for edge in edges {
             if !already_merged.contains(&edge.id) {
                 result.push(edge);
             }


### PR DESCRIPTION
The std::collections::HashMap uses a DOS-resistant but relatively slow hashing algorithm. In the case of osm4routing, HashMap is heavily used while reading .pbf files, even though cryptographic security is not required.

So why don't we replace it with much faster and lighter [ahash](https://github.com/tkaitchuck/aHash) instead?

my small criterion benchmark with osm.pbf of 500.000 people city highways shows around 18% perf improvement:

```
      Running benches/my_benchmark.rs (target/release/deps/my_benchmark-d792725a0a6f62ee)
Gnuplot not found, using plotters backend
Benchmarking benchmark_main: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 103.4s, or reduce sample count to 10.
Benchmarking benchmark_main: Collecting 100 samples in estimated
fib 20                  time:   [1.0229 s 1.0264 s 1.0300 s]
                        change: [-18.570% -18.211% -17.876%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
 ```
 
 The change does not seem to break any public API. However, since it involves a type change, it may require a major version bump (0.8 ?)