### PR TITLE
feat: reexpose osmpbfreader and ahash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ readme = "readme.md"
 license = "MIT"
 
 [dependencies]
-osmpbfreader = "0.17.0"
+osmpbfreader = "0.19.0"
 ahash = "0.8"
 csv = "1.3.0"
 clap = { version = "4.5", features = ["derive"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 geo-types = "0.7"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,8 @@ pub use crate::osm4routing::categorize::{
 pub use crate::osm4routing::models::*;
 pub use crate::osm4routing::reader::{read, Reader};
 pub use crate::osm4routing::writers;
+
+// Reexpose crates that are part of the API
+// It helps consumer being sure they always use the correct version of types
+pub use ahash;
+pub use osmpbfreader;


### PR DESCRIPTION
Some types from both `osmpbfreader` (`NodeId` and `WayId`) and `ahash` (`Edge::tags`) are part of `osm4routing` API. For consumers of the library, it creates a constraint of always needing to upgrade both dependencies together, making sure the versions are the same (or else, the compiler is not happy). One way some libraries deals with this is to reexpose the libraries, so then, the consumer can only depend on `osm4routing` only (and don't need other dependencies). What do you think?

We could also remove these lines https://github.com/rust-transit/osm4routing2/blob/bc78837a4ed53b8be78aa6479c37ebe27546561d/src/osm4routing/models.rs#L5 maybe?